### PR TITLE
Browser initialization for realm other than default

### DIFF
--- a/Pod/Classes/NBNRealmBrowser.m
+++ b/Pod/Classes/NBNRealmBrowser.m
@@ -40,7 +40,7 @@ static NSString *CellIdentifier = @"CellIdentifier";
 }
 
 + (id)browserWithRealm:(RLMRealm *)realm {
-    NBNRealmBrowser *realmBrowser = [[NBNRealmBrowser alloc] init];
+    NBNRealmBrowser *realmBrowser = [[NBNRealmBrowser alloc] initWithRealm:realm];
 #if isIOS8
     UISplitViewController *splitViewController = [[UISplitViewController alloc] init];
     splitViewController.modalPresentationStyle = UIModalTransitionStyleCoverVertical;


### PR DESCRIPTION
Till now, using `+browserWithRealm` didin't work properly - default Realm was opened instead of the one passed by `realm` argument. I'm pretty sure this little change fixes it.
